### PR TITLE
fix(msgraph): soft-delete stale classification rows before upsert

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dbconnectorR
 Title: Connect and Export Data from External Systems to Your Database
-Version: 0.0.0.9019
+Version: 0.0.0.9020
 Authors@R: 
     person("Moritz", "Hemmann", email = "moritz.hemmann@studyflix.de", 
            role = c("aut", "cre"))

--- a/R/msgraph_extern_event_classification.R
+++ b/R/msgraph_extern_event_classification.R
@@ -450,11 +450,22 @@ update_extern_event_classification <- function(con, min_date = Sys.Date() - 90, 
          "(call_event_mapping_id, contact_id) Kombinationen. Bug in Pipeline.")
   }
 
+  # Spalten der Klassifikations-Tabelle, die wir in beiden Teilen des Sync-Sets
+  # (result + out_of_scope) konsistent fuehren muessen. Einmal definiert, damit
+  # spaetere Schema-Erweiterungen nicht stillschweigend in out_of_scope wegfallen
+  # und durch den Upsert mit NA ueberschrieben werden.
+  classification_cols <- c(
+    "call_event_mapping_id", "contact_id", "is_responsible", "is_organizer",
+    "is_no_show", "excluded", "exclusion_reason", "original_created_at",
+    "is_short_lived_event"
+  )
+
   # Scope dieses Runs: alle Mapping-IDs zu Events, die wir gerade klassifiziert
   # haben. Bei use_date_filter = TRUE ist das nur das Date-Fenster.
   processed_event_ids <- unique(events_classified$event_id)
   processed_mapping_ids <- dplyr::tbl(con, I("mapping.msgraph_call_event")) %>%
     dplyr::filter(event_id %in% !!processed_event_ids) %>%
+    dplyr::distinct(id) %>%
     dplyr::pull(id)
 
   # Aktiver Bestand der Klassifikations-Tabelle AUSSERHALB unseres Scopes
@@ -464,17 +475,16 @@ update_extern_event_classification <- function(con, min_date = Sys.Date() - 90, 
   out_of_scope <- dplyr::tbl(con, I("processed.msgraph_extern_event_classification")) %>%
     dplyr::filter(is.na(deleted_on)) %>%
     dplyr::filter(!call_event_mapping_id %in% !!processed_mapping_ids) %>%
-    dplyr::select(
-      call_event_mapping_id, contact_id, is_responsible, is_organizer,
-      is_no_show, excluded, exclusion_reason, original_created_at,
-      is_short_lived_event
-    ) %>%
+    dplyr::select(dplyr::all_of(classification_cols)) %>%
     dplyr::collect()
 
   # Wahrheits-Set = neue Klassifikationen fuer prozessierte Events + unangetasteter
   # Bestand fuer alles ausserhalb. Alle aktiven DB-Zeilen, die hier nicht
   # auftauchen, sind stale und werden vom Upsert soft-deleted.
-  to_upsert <- dplyr::bind_rows(result, out_of_scope)
+  to_upsert <- dplyr::bind_rows(
+    dplyr::select(result, dplyr::all_of(classification_cols)),
+    out_of_scope
+  )
 
   message(paste0("  ", nrow(result), " neue Klassifikationen (Scope), ",
                  nrow(out_of_scope), " unveraendert (Out-of-Scope)"))

--- a/R/msgraph_extern_event_classification.R
+++ b/R/msgraph_extern_event_classification.R
@@ -13,9 +13,22 @@
 #'
 #' @param con A PostgreSQL database connection object.
 #' @param min_date Date. Only process events from this date onwards.
-#'   Defaults to 90 days ago.
+#'   Defaults to 90 days ago. Only used when `use_date_filter = TRUE`.
+#' @param use_date_filter Logical. If TRUE, restrict processing to events with
+#'   `event_date >= min_date`. Default FALSE (full table).
 #'
 #' @return No return value. Updates database table `processed.msgraph_extern_event_classification`.
+#'
+#' @details
+#' Before writing, the function builds a sync-set as the union of (a) the freshly
+#' computed classifications for events in this run and (b) the existing active
+#' rows for events outside the run's scope. It then calls
+#' `Billomatics::postgres_upsert_data(..., delete_missing = TRUE)`, which
+#' soft-deletes any active row not in the sync-set. The net effect: stale
+#' `(call_event_mapping_id, contact_id)` rows from earlier runs — where the
+#' dedup later picked a different winning mapping_id for the same event — are
+#' marked as deleted, while classifications for events outside the date window
+#' (`use_date_filter = TRUE`) are preserved untouched.
 #'
 #' @export
 #' @examples
@@ -424,19 +437,57 @@ update_extern_event_classification <- function(con, min_date = Sys.Date() - 90, 
   message(paste0("  ", sum(result$is_no_show & !result$excluded), " No-Shows (aktiv)"))
   message(paste0("  ", length(unique(result$call_event_mapping_id)), " eindeutige Events"))
 
-  # === 10. UPSERT IN DB ========================================================
+  # === 10. SYNC-SET BAUEN + UPSERT IN DB ======================================
 
-  message("10. Upsert in DB...")
+  message("10. Sync-Set aus aktuellem result + Out-of-Scope-Bestand bauen...")
+
+  # Sanity-Checks am result.
+  if (nrow(result) == 0) {
+    stop("update_extern_event_classification: result ist leer. Abbruch.")
+  }
+  if (anyDuplicated(result[c("call_event_mapping_id", "contact_id")])) {
+    stop("update_extern_event_classification: result enthaelt duplizierte ",
+         "(call_event_mapping_id, contact_id) Kombinationen. Bug in Pipeline.")
+  }
+
+  # Scope dieses Runs: alle Mapping-IDs zu Events, die wir gerade klassifiziert
+  # haben. Bei use_date_filter = TRUE ist das nur das Date-Fenster.
+  processed_event_ids <- unique(events_classified$event_id)
+  processed_mapping_ids <- dplyr::tbl(con, I("mapping.msgraph_call_event")) %>%
+    dplyr::filter(event_id %in% !!processed_event_ids) %>%
+    dplyr::pull(id)
+
+  # Aktiver Bestand der Klassifikations-Tabelle AUSSERHALB unseres Scopes
+  # (= Events anderer Datumsfenster, die wir gerade nicht beruehren) wird 1:1
+  # ins Sync-Set uebernommen, damit postgres_upsert_data mit delete_missing = TRUE
+  # diese Zeilen nicht aus Versehen als geloescht markiert.
+  out_of_scope <- dplyr::tbl(con, I("processed.msgraph_extern_event_classification")) %>%
+    dplyr::filter(is.na(deleted_on)) %>%
+    dplyr::filter(!call_event_mapping_id %in% !!processed_mapping_ids) %>%
+    dplyr::select(
+      call_event_mapping_id, contact_id, is_responsible, is_organizer,
+      is_no_show, excluded, exclusion_reason, original_created_at,
+      is_short_lived_event
+    ) %>%
+    dplyr::collect()
+
+  # Wahrheits-Set = neue Klassifikationen fuer prozessierte Events + unangetasteter
+  # Bestand fuer alles ausserhalb. Alle aktiven DB-Zeilen, die hier nicht
+  # auftauchen, sind stale und werden vom Upsert soft-deleted.
+  to_upsert <- dplyr::bind_rows(result, out_of_scope)
+
+  message(paste0("  ", nrow(result), " neue Klassifikationen (Scope), ",
+                 nrow(out_of_scope), " unveraendert (Out-of-Scope)"))
 
   Billomatics::postgres_upsert_data(
     con,
     "processed",
     "msgraph_extern_event_classification",
-    result,
+    to_upsert,
     match_cols = c("call_event_mapping_id", "contact_id"),
-    delete_missing = FALSE
+    delete_missing = TRUE
   )
 
-  message(paste0("  ", nrow(result), " Zeilen upserted in processed.msgraph_extern_event_classification"))
+  message(paste0("  ", nrow(to_upsert), " Zeilen aktiv nach Upsert"))
   message("Fertig!")
 }

--- a/man/update_extern_event_classification.Rd
+++ b/man/update_extern_event_classification.Rd
@@ -14,7 +14,10 @@ update_extern_event_classification(
 \item{con}{A PostgreSQL database connection object.}
 
 \item{min_date}{Date. Only process events from this date onwards.
-Defaults to 90 days ago.}
+Defaults to 90 days ago. Only used when \code{use_date_filter = TRUE}.}
+
+\item{use_date_filter}{Logical. If TRUE, restrict processing to events with
+\code{event_date >= min_date}. Default FALSE (full table).}
 }
 \value{
 No return value. Updates database table \code{processed.msgraph_extern_event_classification}.
@@ -33,6 +36,16 @@ Key features:
 \item is_short_lived_event flag: events canceled < 24h after creation
 \item Rescheduled meeting detection: same lead, < 2 days apart, no meeting_id
 }
+
+Before writing, the function builds a sync-set as the union of (a) the freshly
+computed classifications for events in this run and (b) the existing active
+rows for events outside the run's scope. It then calls
+\code{Billomatics::postgres_upsert_data(..., delete_missing = TRUE)}, which
+soft-deletes any active row not in the sync-set. The net effect: stale
+\code{(call_event_mapping_id, contact_id)} rows from earlier runs — where the
+dedup later picked a different winning mapping_id for the same event — are
+marked as deleted, while classifications for events outside the date window
+(\code{use_date_filter = TRUE}) are preserved untouched.
 }
 \examples{
 update_extern_event_classification(con)


### PR DESCRIPTION
## Summary
- Build a sync-set in R as the union of (a) the freshly computed result for events processed in this run and (b) the existing active classification rows for events outside the run's scope.
- Hand that sync-set to `Billomatics::postgres_upsert_data(..., delete_missing = TRUE)`. The function soft-deletes any active row that is not in the sync-set — exactly the stale `(call_event_mapping_id, contact_id)` rows.
- Signature unchanged (`min_date`, `use_date_filter` preserved). No caller updates required.

## Why
Diagnosed via Asana [1215159261239929 — Tracking No-Shows Celina](https://app.asana.com/1/734700742714256/project/1211291490555541/task/1215159261239929).

The Shiny No-Show module showed 14 no-shows for Celina in May 2026; manual count was 6. Root cause:

- `mapping.msgraph_call_event` can hold multiple rows per event (one per detected call, indexed by `call_number_on_date`).
- The classification dedup `arrange(event_id, is_no_show_class, desc(call_duration_sec)) %>% distinct(event_id)` picks one winning mapping_id per event. The winner can change between runs (later sync adds a second call → different "best" call wins).
- With the previous `delete_missing = FALSE`, the old `(mapping_id, contact_id)` row was never cleaned up. Two active rows ended up co-existing for the same event — sometimes with contradictory `is_no_show` values.
- Shiny dedups by `call_event_mapping_id`, so both rows survive → the event is double-counted, often with the older one stuck on `is_no_show = TRUE`.

Diagnostic snapshot across the table: 278 `(event_id, contact_id)` combinations with >1 active row, 12 with contradictory `is_no_show`.

## Approach
Pure R / dbplyr — no hand-written SQL, uses the existing upsert path:

```r
processed_event_ids   <- unique(events_classified$event_id)
processed_mapping_ids <- tbl(con, I("mapping.msgraph_call_event")) %>%
  filter(event_id %in% !!processed_event_ids) %>%
  pull(id)

out_of_scope <- tbl(con, I("processed.msgraph_extern_event_classification")) %>%
  filter(is.na(deleted_on)) %>%
  filter(!call_event_mapping_id %in% !!processed_mapping_ids) %>%
  select(<same columns as result>) %>%
  collect()

to_upsert <- bind_rows(result, out_of_scope)

Billomatics::postgres_upsert_data(
  con, "processed", "msgraph_extern_event_classification",
  to_upsert,
  match_cols = c("call_event_mapping_id", "contact_id"),
  delete_missing = TRUE
)
```

Works correctly for both full runs (`use_date_filter = FALSE`) and partial runs (`use_date_filter = TRUE`) — in the partial case, the out-of-scope rows are added to the sync-set so they don't get incorrectly soft-deleted.

## Test plan
- [ ] Deploy via `remotes::install_github`, run `do/main.R` in base-35 once.
- [ ] Re-run the Celina-May diagnostic SQL — expect ~6 no-shows instead of 14.
- [ ] Verify a partial run with `use_date_filter = TRUE` does not soft-delete classification rows for events outside the date window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)