### PR TITLE
feat(dsgvo): suppression hook in msgraph calls/events/booking (B2)

### DIFF
--- a/R/msgraph_calls.R
+++ b/R/msgraph_calls.R
@@ -13,6 +13,11 @@
 #'   Calls are retrieved tenant-wide from the API and then reduced to those
 #'   where at least one participant matches one of the given users. If NULL
 #'   (default), all retrieved calls are written.
+#' @param suppression_pepper Optional. Character pepper for DSGVO suppression.
+#'   If non-NULL, loads the suppression list via
+#'   \code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
+#'   persons in \code{call_meeting_record} before writing contacts and
+#'   participants. Default \code{NULL} leaves behaviour unchanged.
 #'
 #' @return No return value. Updates database tables with new call records and participants.
 #'
@@ -22,7 +27,7 @@
 #' msgraph_update_calls(con, access_token)
 #' msgraph_update_calls(con, access_token, days_back = 30)
 #' msgraph_update_calls(con, access_token, user_id = c(23, 47, 89))
-msgraph_update_calls <- function(con, access_token, days_back = NULL, user_id = NULL) {
+msgraph_update_calls <- function(con, access_token, days_back = NULL, user_id = NULL, suppression_pepper = NULL) {
 
   old_calls_file <- dplyr::tbl(con, I("raw.msgraph_calls")) %>% dplyr::collect()
 
@@ -79,6 +84,11 @@ msgraph_update_calls <- function(con, access_token, days_back = NULL, user_id = 
     if (nrow(call_meeting_record) == 0) {
       print("No calls to upsert after filtering.")
     } else {
+      if (!is.null(suppression_pepper)) {
+        sup <- Billomatics::dsgvo_load_suppression(con)
+        call_meeting_record <- Billomatics::dsgvo_suppress_msgraph_record(
+          call_meeting_record, sup$email_hashes, suppression_pepper)
+      }
       update_calls(con, call_meeting_record)
       update_contacts_from_calls(con, call_meeting_record)
       update_call_participants(con, call_meeting_record)

--- a/R/msgraph_events.R
+++ b/R/msgraph_events.R
@@ -10,6 +10,11 @@
 #' @param user_id Optional. Internal user ID(s) to filter calendar events. Accepts a
 #'   single value or a vector. If `NULL` (default), all internal, non-deleted users
 #'   from `raw.msgraph_users` are processed.
+#' @param suppression_pepper Optional. Character pepper for DSGVO suppression.
+#'   If non-NULL, loads the suppression list via
+#'   \code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
+#'   persons in \code{msgraph_event_participants} before writing contacts and
+#'   participants. Default \code{NULL} leaves behaviour unchanged.
 #'
 #' @return No return value. Updates database tables with new calendar events and participants.
 #'
@@ -19,7 +24,7 @@
 #' msgraph_update_events(con, access_token, startDate)
 #' msgraph_update_events(con, access_token, startDate, user_id = 23)
 #' msgraph_update_events(con, access_token, startDate, user_id = c(23, 47, 89))
-msgraph_update_events <- function(con, access_token, startDate, user_id = NULL) {
+msgraph_update_events <- function(con, access_token, startDate, user_id = NULL, suppression_pepper = NULL) {
 
   all_users <- dplyr::tbl(con, I("raw.msgraph_users")) %>%
     dplyr::filter(is_internal & !is_deleted)
@@ -91,6 +96,12 @@ msgraph_update_events <- function(con, access_token, startDate, user_id = NULL) 
     dplyr::ungroup()
 
   update_events(con, all_calendar_events_, startDate, source = "calendar")
+  if (!is.null(suppression_pepper)) {
+    sup <- Billomatics::dsgvo_load_suppression(con)
+    msgraph_event_participants <- Billomatics::dsgvo_suppress_msgraph_record(
+      msgraph_event_participants, sup$email_hashes, suppression_pepper,
+      mail_col = "attendees_emailAddress_address", name_col = "attendees_emailAddress_name")
+  }
   update_contacts_from_events(con, msgraph_event_participants)
   update_event_participants(con, msgraph_event_participants, source = "calendar")
 }
@@ -868,13 +879,18 @@ add_sdr_as_booking_organizer <- function(con, all_parts_df) {
 #'   a token provider closure produced by [msgraph_make_token_provider()]. A
 #'   provider is auto-refreshed before expiry and on 401 responses.
 #' @param startDate Date from which to retrieve appointments.
+#' @param suppression_pepper Optional. Character pepper for DSGVO suppression.
+#'   If non-NULL, loads the suppression list via
+#'   \code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
+#'   persons in \code{all_parts_df} before writing contacts and participants.
+#'   Default \code{NULL} leaves behaviour unchanged.
 #'
 #' @return No return value. Updates database tables.
 #' @export
 #'
 #' @examples
 #' msgraph_update_booking_appointments(con, access_token, startDate)
-msgraph_update_booking_appointments <- function(con, access_token, startDate) {
+msgraph_update_booking_appointments <- function(con, access_token, startDate, suppression_pepper = NULL) {
   # ---- start ---- #
 
   # 1. List businesses
@@ -926,6 +942,12 @@ msgraph_update_booking_appointments <- function(con, access_token, startDate) {
   update_events(con, all_events_df, startDate, source = "booking")
 
   if (!is.null(all_parts_df) && nrow(all_parts_df) > 0) {
+    if (!is.null(suppression_pepper)) {
+      sup <- Billomatics::dsgvo_load_suppression(con)
+      all_parts_df <- Billomatics::dsgvo_suppress_msgraph_record(
+        all_parts_df, sup$email_hashes, suppression_pepper,
+        mail_col = "attendees_emailAddress_address", name_col = "attendees_emailAddress_name")
+    }
     update_contacts_from_events(con, all_parts_df)
     update_event_participants(con, all_parts_df, source = "booking")
   }

--- a/R/msgraph_events.R
+++ b/R/msgraph_events.R
@@ -95,13 +95,16 @@ msgraph_update_events <- function(con, access_token, startDate, user_id = NULL, 
     dplyr::summarise(is_organizer = any(is_organizer)) %>%
     dplyr::ungroup()
 
-  update_events(con, all_calendar_events_, startDate, source = "calendar")
+  # DSGVO-Suppression VOR allen Writes: msgraph_event_participants traegt die Attendee-PII,
+  # die in raw.msgraph_contacts + raw.msgraph_event_participants fliesst. (update_events schreibt
+  # nur Struktur-Spalten aus all_calendar_events_ und droppt attendees/organizer.)
   if (!is.null(suppression_pepper)) {
     sup <- Billomatics::dsgvo_load_suppression(con)
     msgraph_event_participants <- Billomatics::dsgvo_suppress_msgraph_record(
       msgraph_event_participants, sup$email_hashes, suppression_pepper,
       mail_col = "attendees_emailAddress_address", name_col = "attendees_emailAddress_name")
   }
+  update_events(con, all_calendar_events_, startDate, source = "calendar")
   update_contacts_from_events(con, msgraph_event_participants)
   update_event_participants(con, msgraph_event_participants, source = "calendar")
 }
@@ -882,8 +885,8 @@ add_sdr_as_booking_organizer <- function(con, all_parts_df) {
 #' @param suppression_pepper Optional. Character pepper for DSGVO suppression.
 #'   If non-NULL, loads the suppression list via
 #'   \code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
-#'   persons in \code{all_parts_df} before writing contacts and participants.
-#'   Default \code{NULL} leaves behaviour unchanged.
+#'   persons in the booking participants before they are written to contacts and
+#'   event participants. Default \code{NULL} leaves behaviour unchanged.
 #'
 #' @return No return value. Updates database tables.
 #' @export
@@ -942,6 +945,8 @@ msgraph_update_booking_appointments <- function(con, access_token, startDate, su
   update_events(con, all_events_df, startDate, source = "booking")
 
   if (!is.null(all_parts_df) && nrow(all_parts_df) > 0) {
+    # DSGVO-Suppression VOR den all_parts_df-Writes (Contacts + Participants). update_events oben
+    # nutzt all_events_df (Struktur-Spalten), nicht all_parts_df.
     if (!is.null(suppression_pepper)) {
       sup <- Billomatics::dsgvo_load_suppression(con)
       all_parts_df <- Billomatics::dsgvo_suppress_msgraph_record(

--- a/man/msgraph_update_booking_appointments.Rd
+++ b/man/msgraph_update_booking_appointments.Rd
@@ -4,7 +4,12 @@
 \alias{msgraph_update_booking_appointments}
 \title{Retrieve and Update Booking Appointments From MSGraph}
 \usage{
-msgraph_update_booking_appointments(con, access_token, startDate)
+msgraph_update_booking_appointments(
+  con,
+  access_token,
+  startDate,
+  suppression_pepper = NULL
+)
 }
 \arguments{
 \item{con}{A PostgreSQL database connection object.}
@@ -14,6 +19,12 @@ a token provider closure produced by \code{\link[=msgraph_make_token_provider]{m
 provider is auto-refreshed before expiry and on 401 responses.}
 
 \item{startDate}{Date from which to retrieve appointments.}
+
+\item{suppression_pepper}{Optional. Character pepper for DSGVO suppression.
+If non-NULL, loads the suppression list via
+\code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
+persons in \code{all_parts_df} before writing contacts and participants.
+Default \code{NULL} leaves behaviour unchanged.}
 }
 \value{
 No return value. Updates database tables.

--- a/man/msgraph_update_booking_appointments.Rd
+++ b/man/msgraph_update_booking_appointments.Rd
@@ -23,8 +23,8 @@ provider is auto-refreshed before expiry and on 401 responses.}
 \item{suppression_pepper}{Optional. Character pepper for DSGVO suppression.
 If non-NULL, loads the suppression list via
 \code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
-persons in \code{all_parts_df} before writing contacts and participants.
-Default \code{NULL} leaves behaviour unchanged.}
+persons in the booking participants before they are written to contacts and
+event participants. Default \code{NULL} leaves behaviour unchanged.}
 }
 \value{
 No return value. Updates database tables.

--- a/man/msgraph_update_calls.Rd
+++ b/man/msgraph_update_calls.Rd
@@ -4,7 +4,13 @@
 \alias{msgraph_update_calls}
 \title{Retrieve Call Records from MSGraph and Update Database}
 \usage{
-msgraph_update_calls(con, access_token, days_back = NULL, user_id = NULL)
+msgraph_update_calls(
+  con,
+  access_token,
+  days_back = NULL,
+  user_id = NULL,
+  suppression_pepper = NULL
+)
 }
 \arguments{
 \item{con}{A PostgreSQL database connection object.}
@@ -21,6 +27,12 @@ uses the last update timestamp from the database.}
 Calls are retrieved tenant-wide from the API and then reduced to those
 where at least one participant matches one of the given users. If NULL
 (default), all retrieved calls are written.}
+
+\item{suppression_pepper}{Optional. Character pepper for DSGVO suppression.
+If non-NULL, loads the suppression list via
+\code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
+persons in \code{call_meeting_record} before writing contacts and
+participants. Default \code{NULL} leaves behaviour unchanged.}
 }
 \value{
 No return value. Updates database tables with new call records and participants.

--- a/man/msgraph_update_events.Rd
+++ b/man/msgraph_update_events.Rd
@@ -4,7 +4,13 @@
 \alias{msgraph_update_events}
 \title{Retrieve and Update Calendar Events from MSGraph}
 \usage{
-msgraph_update_events(con, access_token, startDate, user_id = NULL)
+msgraph_update_events(
+  con,
+  access_token,
+  startDate,
+  user_id = NULL,
+  suppression_pepper = NULL
+)
 }
 \arguments{
 \item{con}{A PostgreSQL database connection object.}
@@ -18,6 +24,12 @@ provider is auto-refreshed before expiry and on 401 responses.}
 \item{user_id}{Optional. Internal user ID(s) to filter calendar events. Accepts a
 single value or a vector. If \code{NULL} (default), all internal, non-deleted users
 from \code{raw.msgraph_users} are processed.}
+
+\item{suppression_pepper}{Optional. Character pepper for DSGVO suppression.
+If non-NULL, loads the suppression list via
+\code{Billomatics::dsgvo_load_suppression()} and tombstones PII of deleted
+persons in \code{msgraph_event_participants} before writing contacts and
+participants. Default \code{NULL} leaves behaviour unchanged.}
 }
 \value{
 No return value. Updates database tables with new calendar events and participants.

--- a/tests/testthat/test-suppression.R
+++ b/tests/testthat/test-suppression.R
@@ -1,0 +1,12 @@
+test_that("dsgvo_suppress_msgraph_record maps both column shapes to the stable tombstone", {
+  suppressMessages(library(Billomatics))
+  blocked <- dsgvo_hash_email("t@x.de", "p")
+  calls <- data.frame(call_identity_mail = "t@x.de", call_identity_name = "T", stringsAsFactors = FALSE)
+  ev <- data.frame(attendees_emailAddress_address = "t@x.de", attendees_emailAddress_name = "T", stringsAsFactors = FALSE)
+  oc <- dsgvo_suppress_msgraph_record(calls, blocked, "p")
+  oe <- dsgvo_suppress_msgraph_record(ev, blocked, "p",
+          mail_col = "attendees_emailAddress_address", name_col = "attendees_emailAddress_name")
+  ts <- dsgvo_email_tombstone(blocked)
+  expect_equal(oc$call_identity_mail, ts)
+  expect_equal(oe$attendees_emailAddress_address, ts)
+})

--- a/tests/testthat/test-suppression.R
+++ b/tests/testthat/test-suppression.R
@@ -10,3 +10,12 @@ test_that("dsgvo_suppress_msgraph_record maps both column shapes to the stable t
   expect_equal(oc$call_identity_mail, ts)
   expect_equal(oe$attendees_emailAddress_address, ts)
 })
+
+test_that("no-op when there is nothing to suppress (mirrors the suppression_pepper = NULL path)", {
+  suppressMessages(library(Billomatics))
+  calls <- data.frame(call_identity_mail = "t@x.de", call_identity_name = "T", stringsAsFactors = FALSE)
+  # leere Sperrliste -> Record unveraendert (entspricht dem uebersprungenen Hook bei pepper = NULL)
+  out <- dsgvo_suppress_msgraph_record(calls, character(0), "p")
+  expect_equal(out$call_identity_mail, "t@x.de")
+  expect_equal(out$call_identity_name, "T")
+})


### PR DESCRIPTION
Teil der DSGVO-Feature **Suppression-on-Ingest** (B2). Optionaler `suppression_pepper = NULL` in den drei MS-Graph-Funktionen (`msgraph_update_calls`, `msgraph_update_events`, `msgraph_update_booking_appointments`):
- Wenn gesetzt, wird PII gesperrter Personen **vor** den Contact-/Participant-Writes getombstoned (`Billomatics::dsgvo_suppress_msgraph_record` upstream auf den Record-DF) → Participant-Join bleibt auflösbar
- Spalten: calls = `call_identity_mail/_name` (Default), events/booking = `attendees_emailAddress_address/_name`
- **Additiv** (`NULL`-Default) → kein Bruch für andere Consumer

Setzt die neue Billomatics-Version voraus.
