### PR TITLE
Retry transcript downloads on 5xx via fetch_with_retry

### DIFF
--- a/R/msgraph_transcripts_load.R
+++ b/R/msgraph_transcripts_load.R
@@ -523,7 +523,7 @@ retry_meeting_metadata_with_participants <- function(access_token,
   }
 
   if (nrow(candidate_calls) == 0) {
-    message("[DEBUG] No candidate calls found for meeting metadata retry")
+    message("[WARNING] No candidate calls found for meeting metadata retry")
     return(NULL)
   }
 
@@ -632,7 +632,7 @@ retry_meeting_metadata_with_participants <- function(access_token,
     }
   }
 
-  message("[DEBUG] get_meeting_metadata failed for all ",
+  message("[WARNING] get_meeting_metadata failed for all ",
           length(retry_uids), " alternative users")
   return(NULL)
 }

--- a/R/msgraph_transcripts_load.R
+++ b/R/msgraph_transcripts_load.R
@@ -644,20 +644,17 @@ retry_meeting_metadata_with_participants <- function(access_token,
 #' @keywords internal
 get_content_transcript_url <- function(access_token, content_url) {
   # Transcript content is VTT text, not JSON. fetch_with_retry retries 5xx/429
-  # and refreshes on 401; it returns NULL when all retries are exhausted or on a
-  # 404.
+  # and refreshes on 401. error_on_failure = TRUE makes it raise with the last
+  # HTTP status and response body on definitive failure (exhausted retries or a
+  # 404), so the caller's tryCatch captures that detail in e$message, logs it and
+  # stores a NULL-content placeholder row which the next run re-attempts.
   content_text <- fetch_with_retry(
-    url          = content_url,
-    access_token = access_token,
-    accept       = "text/vtt",
-    parse        = "text"
+    url              = content_url,
+    access_token     = access_token,
+    accept           = "text/vtt",
+    parse            = "text",
+    error_on_failure = TRUE
   )
-
-  # Raise on definitive failure so the caller's tryCatch logs it and stores a
-  # NULL-content placeholder row, which the next run re-attempts (self-heal).
-  if (is.null(content_text) || length(content_text) == 0) {
-    stop("Failed to fetch transcript content after retries (see fetch_with_retry messages)")
-  }
 
   return(content_text)
 }

--- a/R/msgraph_transcripts_load.R
+++ b/R/msgraph_transcripts_load.R
@@ -430,15 +430,9 @@ retrieve_transcript_metadata <- function(access_token, user_id, start_date, end_
     "',startDateTime=", start_date, ",endDateTime=", end_date, ")"
   )
 
-  response <- httr::GET(url, httr::add_headers(Authorization = paste("Bearer", resolve_token(access_token))))
-
-  status <- httr::http_status(response)
-
-  if (status$category != "Success") {
-    return(NULL)
-  }
-
-  parsed_response <- httr::content(response, as = "parsed", type = "application/json")
+  # fetch_with_retry handles 401 refresh, 429 throttling and 5xx retries;
+  # returns NULL when all retries are exhausted.
+  parsed_response <- fetch_with_retry(url, access_token)
 
   if (!is.list(parsed_response) || is.null(parsed_response$value) ||
       length(parsed_response$value) == 0) {
@@ -460,18 +454,17 @@ get_meeting_metadata <- function(access_token, user_id, meeting_id) {
     "/onlineMeetings/", meeting_id
   )
 
-  response <- httr::GET(
-    url,
-    httr::add_headers(Authorization = paste("Bearer", resolve_token(access_token)))
-  )
+  # fetch_with_retry handles 401 refresh, 429 throttling and 5xx retries.
+  # Returns NULL on a 404 (meeting not visible to this user) or after exhausting
+  # retries — both cases trigger the participant-based retry in the caller.
+  parsed_response <- fetch_with_retry(url, access_token)
 
-  if (httr::http_status(response)$category != "Success") {
-    message("[WARNING] get_meeting_metadata HTTP ", httr::status_code(response),
-            " for user ", user_id, ", meeting ", meeting_id)
+  if (is.null(parsed_response) || length(parsed_response) == 0) {
+    message("[DEBUG] get_meeting_metadata failed (empty/404/retries exhausted) ",
+            "for user ", user_id, ", meeting ", meeting_id,
+            " — see fetch_with_retry messages")
     return(NULL)
   }
-
-  parsed_response <- httr::content(response, as = "parsed", type = "application/json")
 
   return(parsed_response)
 }
@@ -530,7 +523,7 @@ retry_meeting_metadata_with_participants <- function(access_token,
   }
 
   if (nrow(candidate_calls) == 0) {
-    message("[WARNING] No candidate calls found for meeting metadata retry")
+    message("[DEBUG] No candidate calls found for meeting metadata retry")
     return(NULL)
   }
 
@@ -639,7 +632,7 @@ retry_meeting_metadata_with_participants <- function(access_token,
     }
   }
 
-  message("[WARNING] get_meeting_metadata failed for all ",
+  message("[DEBUG] get_meeting_metadata failed for all ",
           length(retry_uids), " alternative users")
   return(NULL)
 }
@@ -650,27 +643,22 @@ retry_meeting_metadata_with_participants <- function(access_token,
 #' Downloads transcript content (VTT format)
 #' @keywords internal
 get_content_transcript_url <- function(access_token, content_url) {
-  response <- httr::GET(
-    content_url,
-    httr::add_headers(
-      Authorization = paste("Bearer", resolve_token(access_token)),
-      Accept = "text/vtt"
-    )
+  # Transcript content is VTT text, not JSON. fetch_with_retry retries 5xx/429
+  # and refreshes on 401; it returns NULL when all retries are exhausted or on a
+  # 404.
+  content_text <- fetch_with_retry(
+    url          = content_url,
+    access_token = access_token,
+    accept       = "text/vtt",
+    parse        = "text"
   )
 
-  if (httr::http_status(response)$category != "Success") {
-    body <- tryCatch(
-      httr::content(response, as = "text", encoding = "UTF-8"),
-      error = function(e) "<no body>"
-    )
-    stop(sprintf(
-      "Failed to fetch transcript content (HTTP %d): %s",
-      httr::status_code(response),
-      substr(body, 1, 300)
-    ))
+  # Raise on definitive failure so the caller's tryCatch logs it and stores a
+  # NULL-content placeholder row, which the next run re-attempts (self-heal).
+  if (is.null(content_text) || length(content_text) == 0) {
+    stop("Failed to fetch transcript content after retries (see fetch_with_retry messages)")
   }
 
-  content_text <- httr::content(response, as = "text", encoding = "UTF-8")
   return(content_text)
 }
 

--- a/R/utils_msgraph_func.R
+++ b/R/utils_msgraph_func.R
@@ -143,7 +143,9 @@ resolve_token <- function(access_token, force_refresh = FALSE) {
   }
 }
 
-fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, delay = 2) {
+fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, delay = 2,
+                             accept = "application/json", parse = c("json", "text", "raw")) {
+  parse <- match.arg(parse)
   attempt <- 1
   success <- FALSE
   response_content <- NULL
@@ -151,10 +153,14 @@ fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, de
 
   while (attempt <= max_retries && !success) {
     bearer <- resolve_token(access_token)
+    req_headers <- httr::add_headers(
+      Authorization = paste("Bearer", bearer),
+      Accept = accept
+    )
     if (length(query) == 0) {
-      response <- httr::GET(url, httr::add_headers(Authorization = paste("Bearer", bearer)))
+      response <- httr::GET(url, req_headers)
     } else {
-      response <- httr::GET(url, query = query, httr::add_headers(Authorization = paste("Bearer", bearer)))
+      response <- httr::GET(url, query = query, req_headers)
     }
 
     if (response$status_code == 401 && !auth_refresh_done && is.function(access_token)) {
@@ -175,7 +181,7 @@ fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, de
         Sys.sleep(backoff_time)
       }
       attempt <- attempt + 1
-    } else if (response$status_code > 500) {
+    } else if (response$status_code >= 500) {
       message(paste("\nAttempt", attempt, "failed with status", response$status_code))
       attempt <- attempt + 1
       Sys.sleep(delay)
@@ -187,8 +193,13 @@ fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, de
         message("401 Unauthorized — token appears expired. ",
                 "Use msgraph_make_token_provider() instead of a raw token for auto-refresh.")
       }
-      # Parse the content
-      response_content <- httr::content(response, as = "parsed", type = "application/json")
+      # Parse the content according to the requested format
+      response_content <- switch(
+        parse,
+        json = httr::content(response, as = "parsed", type = "application/json"),
+        text = httr::content(response, as = "text", encoding = "UTF-8"),
+        raw  = httr::content(response, as = "raw")
+      )
       success <- TRUE
     }
   }

--- a/R/utils_msgraph_func.R
+++ b/R/utils_msgraph_func.R
@@ -144,12 +144,14 @@ resolve_token <- function(access_token, force_refresh = FALSE) {
 }
 
 fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, delay = 2,
-                             accept = "application/json", parse = c("json", "text", "raw")) {
+                             accept = "application/json", parse = c("json", "text", "raw"),
+                             error_on_failure = FALSE) {
   parse <- match.arg(parse)
   attempt <- 1
   success <- FALSE
   response_content <- NULL
   auth_refresh_done <- FALSE
+  response <- NULL  # holds the most recent response for failure diagnostics
 
   while (attempt <= max_retries && !success) {
     bearer <- resolve_token(access_token)
@@ -204,8 +206,17 @@ fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, de
     }
   }
 
-  if (!success && attempt > max_retries) {
-    message(paste("Failed to fetch content after", max_retries, "attempts:", url))
+  if (!success) {
+    last_status <- if (is.null(response)) NA_integer_ else response$status_code
+    last_body <- tryCatch(
+      substr(httr::content(response, as = "text", encoding = "UTF-8"), 1, 300),
+      error = function(e) "<no body>"
+    )
+    message(sprintf("Failed to fetch content (last HTTP %s): %s", last_status, url))
+    if (error_on_failure) {
+      stop(sprintf("Failed to fetch content (HTTP %s) from %s: %s",
+                   last_status, url, last_body))
+    }
   }
 
   return(response_content)

--- a/R/utils_msgraph_func.R
+++ b/R/utils_msgraph_func.R
@@ -144,7 +144,7 @@ resolve_token <- function(access_token, force_refresh = FALSE) {
 }
 
 fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, delay = 2,
-                             accept = "application/json", parse = c("json", "text", "raw"),
+                             accept = NULL, parse = c("json", "text", "raw"),
                              error_on_failure = FALSE) {
   parse <- match.arg(parse)
   attempt <- 1
@@ -155,10 +155,14 @@ fetch_with_retry <- function(url, access_token, query = c(), max_retries = 5, de
 
   while (attempt <= max_retries && !success) {
     bearer <- resolve_token(access_token)
-    req_headers <- httr::add_headers(
-      Authorization = paste("Bearer", bearer),
-      Accept = accept
-    )
+    # Only send an Accept header when one is explicitly requested (e.g. text/vtt
+    # for transcript content). JSON callers pass none, so their request stays
+    # byte-for-byte identical to the pre-retry implementation.
+    req_headers <- if (is.null(accept)) {
+      httr::add_headers(Authorization = paste("Bearer", bearer))
+    } else {
+      httr::add_headers(Authorization = paste("Bearer", bearer), Accept = accept)
+    }
     if (length(query) == 0) {
       response <- httr::GET(url, req_headers)
     } else {

--- a/tests/testthat/test-fetch_with_retry.R
+++ b/tests/testthat/test-fetch_with_retry.R
@@ -69,3 +69,28 @@ test_that("404 returns NULL/empty so the caller can fall back", {
   out <- run(list(list(status_code = 404, body = "not found")))
   expect_true(is.null(out) || length(out) == 0)
 })
+
+# Captures the headers actually attached to the GET request.
+capture_headers <- function(...) {
+  captured <- NULL
+  cap_get <- function(url, ...) {
+    for (d in list(...)) if (inherits(d, "request")) captured <<- d$headers
+    list(status_code = 200, body = "WEBVTT", payload = list(ok = TRUE))
+  }
+  testthat::with_mocked_bindings(
+    fetch_with_retry(url = "https://x", access_token = "TOKEN", delay = 0, ...),
+    GET = cap_get, content = fake_content, headers = fake_headers, .package = "httr"
+  )
+  captured
+}
+
+test_that("no Accept header is sent by default (JSON callers stay unchanged)", {
+  hdrs <- capture_headers()
+  expect_false("Accept" %in% names(hdrs))
+  expect_true("Authorization" %in% names(hdrs))
+})
+
+test_that("an explicit accept is sent (e.g. text/vtt for transcript content)", {
+  hdrs <- capture_headers(accept = "text/vtt", parse = "text")
+  expect_equal(unname(hdrs[["Accept"]]), "text/vtt")
+})

--- a/tests/testthat/test-fetch_with_retry.R
+++ b/tests/testthat/test-fetch_with_retry.R
@@ -1,0 +1,71 @@
+# Unit tests for fetch_with_retry(): retry behaviour, parse modes, error surfacing.
+# httr is mocked, so these run offline with no credentials or network.
+
+# --- fakes -------------------------------------------------------------------
+# A sequence of responses is supplied; each GET pops the next one.
+make_get <- function(responses) {
+  i <- 0
+  function(url, ...) {
+    i <<- i + 1
+    responses[[min(i, length(responses))]]
+  }
+}
+# content() dispatches on `as`: "text" -> body string, "raw" -> raw, else parsed.
+fake_content <- function(x, as = "parsed", type = NULL, encoding = NULL) {
+  if (identical(as, "text")) return(if (is.null(x$body)) "<no body>" else x$body)
+  if (identical(as, "raw"))  return(if (is.null(x$raw)) as.raw(0) else x$raw)
+  x$payload
+}
+fake_headers <- function(x) if (is.null(x$headers)) list() else x$headers
+
+run <- function(responses, ...) {
+  testthat::with_mocked_bindings(
+    fetch_with_retry(url = "https://x", access_token = "TOKEN", delay = 0, ...),
+    GET = make_get(responses), content = fake_content, headers = fake_headers,
+    .package = "httr"
+  )
+}
+
+# --- tests -------------------------------------------------------------------
+
+test_that("200 + parse=json returns the parsed body", {
+  out <- run(list(list(status_code = 200, payload = list(value = "ok"))))
+  expect_equal(out$value, "ok")
+})
+
+test_that("200 + parse=text returns raw text, not JSON-parsed", {
+  out <- run(list(list(status_code = 200, body = "WEBVTT\n00:00 hi")), parse = "text")
+  expect_true(is.character(out))
+  expect_match(out, "WEBVTT")
+})
+
+test_that("HTTP 500 is retried, not mis-parsed as success (>= 500 fix)", {
+  out <- run(rep(list(list(status_code = 500, payload = list(error = "boom"))), 3),
+             max_retries = 3)
+  expect_null(out)
+})
+
+test_that("a transient 5xx followed by 200 recovers within the same call", {
+  out <- run(list(list(status_code = 502, body = "bad gateway"),
+                  list(status_code = 200, payload = list(value = "recovered"))),
+             max_retries = 5)
+  expect_equal(out$value, "recovered")
+})
+
+test_that("error_on_failure = TRUE raises with the last HTTP status and body", {
+  expect_error(
+    run(rep(list(list(status_code = 502, body = "BadGateway detail")), 2),
+        max_retries = 2, error_on_failure = TRUE),
+    regexp = "502.*BadGateway detail"
+  )
+})
+
+test_that("error_on_failure = FALSE (default) returns NULL on failure", {
+  out <- run(rep(list(list(status_code = 503, body = "x")), 2), max_retries = 2)
+  expect_null(out)
+})
+
+test_that("404 returns NULL/empty so the caller can fall back", {
+  out <- run(list(list(status_code = 404, body = "not found")))
+  expect_true(is.null(out) || length(out) == 0)
+})


### PR DESCRIPTION
## Problem

Der nächtliche Transcript-Lauf ist an einem transienten **HTTP 502** von MS Graph beim Content-Download gescheitert — ohne Retry:

```
[DEBUG] DOWNLOADING transcript content...
[DEBUG] Download FAILED: Failed to fetch transcript content (HTTP 502): {"error":{"code":"BadGateway", ...}}
```

Ursache: Die drei Graph-Calls im Transcript-Modul (`retrieve_transcript_metadata`, `get_meeting_metadata`, `get_content_transcript_url`) nutzten rohes `httr::GET` **ohne** die bereits vorhandene `fetch_with_retry()`-Logik. Ein 5xx brach sofort ab; der Record heilte erst im Folgelauf (~24 h später) über den NULL-Content-Rescan.

## Änderungen

- **Alle drei Transcript-Calls auf `fetch_with_retry()` verdrahtet** (401-Refresh, 429-Backoff, 5xx-Retry). `get_content_transcript_url` wirft bei endgültigem Fehlschlag weiterhin `stop()`, sodass der bestehende `tryCatch` den NA-Platzhalter schreibt und der Self-Heal erhalten bleibt.
- **`fetch_with_retry()` um `accept`/`parse` erweitert** → kann jetzt auch VTT-**Text** liefern (`parse = "text"`), nicht nur JSON. Rückwärtskompatibel; bestehende Aufrufer unverändert.
- **Off-by-one gefixt:** Retry bei `status_code >= 500` statt `> 500`. Vorher fiel ein glattes HTTP 500 durch und wurde fälschlich als Erfolg geparst.

**Netto:** transiente 502/500 werden jetzt bis zu 5× (à 2 s Backoff) im selben Lauf wiederholt statt erst nach 24 h.

## Nicht in diesem PR (bewusst)

- Weitere rohe MSGraph-`httr::GET` (`msgraph_calls.R:122/322`, `msgraph_users.R:52`) haben dieselbe 5xx-Anfälligkeit — separater Scope.
- CRM/Central-Station-Calls nutzen andere Auth, passen nicht 1:1 auf `fetch_with_retry`.
- Kein `DESCRIPTION`-Version-Bump.

## Test

- Beide Dateien `parse()`-geprüft (OK). Keine bestehenden Tests hängen an den betroffenen Funktionen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)