### PR TITLE
Tolerate CRM attachments without file metadata

### DIFF
--- a/R/crm_protocols.R
+++ b/R/crm_protocols.R
@@ -200,7 +200,8 @@ crm_update_protocols <- function(con, keys, is_daily, override_last_update = NA,
     resolve_user_ids(all_users, "user_id") %>%
     resolve_protocol_id(all_protocols, "protocol_id") %>%
     dplyr::distinct(crm_attachment_id, .keep_all = TRUE) %>%
-    tidyr::drop_na(user_id)
+    tidyr::drop_na(user_id) %>%
+    drop_attachments_without_file_metadata("protocol")
 
   # Attachments aus DB die zu heruntergeladenen oder gelöschten Protokollen gehören,
   # aber nicht im Download sind → als gelöscht markieren
@@ -228,7 +229,8 @@ crm_update_protocols <- function(con, keys, is_daily, override_last_update = NA,
     resolve_comment_ids(all_comments, "comment_id") %>%
     tidyr::drop_na(comment_id) %>%
     dplyr::distinct(crm_attachment_id, .keep_all = TRUE) %>%
-    tidyr::drop_na(user_id)
+    tidyr::drop_na(user_id) %>%
+    drop_attachments_without_file_metadata("comment")
 
   # Comment-Attachments aus DB deren Prefix gesucht wurde,
   # aber nicht im Download sind → als gelöscht markieren
@@ -914,6 +916,40 @@ simplify_protocols <- function(protocols) {
   
   return(all_protocols)
 
+}
+
+#' Drop attachments without file metadata
+#'
+#' CentralStation occasionally returns attachment objects with no file behind
+#' them (empty or failed uploads): \code{content_type} and \code{file_size}
+#' come back as \code{NA}. Both columns are \code{NOT NULL} in the raw schema,
+#' so an unfiltered upsert aborts the entire ingestion job. This helper removes
+#' such rows before the upsert and warns, listing the affected
+#' \code{crm_attachment_id}s so the anomaly stays visible.
+#'
+#' @param attachments A data frame of prepared attachments with at least the
+#'   columns \code{crm_attachment_id}, \code{content_type} and \code{file_size}.
+#' @param attachment_kind Character label used in the warning message, e.g.
+#'   \code{"protocol"} or \code{"comment"}.
+#' @return The input data frame with metadata-less rows removed.
+#' @noRd
+drop_attachments_without_file_metadata <- function(attachments, attachment_kind = "protocol") {
+
+  # ---- start ---- #
+
+  if (nrow(attachments) == 0) return(attachments)
+
+  missing_metadata <- is.na(attachments$content_type) | is.na(attachments$file_size)
+
+  if (any(missing_metadata)) {
+    dropped_ids <- attachments$crm_attachment_id[missing_metadata]
+    warning(sprintf(
+      "Dropping %d %s attachment(s) without file metadata (content_type/file_size NA): %s",
+      length(dropped_ids), attachment_kind, paste(dropped_ids, collapse = ", ")
+    ))
+  }
+
+  attachments[!missing_metadata, , drop = FALSE]
 }
 
 # grepl with a single huge alternation pattern can exceed R's regex memory limit.

--- a/tests/testthat/test-crm_protocol_attachments.R
+++ b/tests/testthat/test-crm_protocol_attachments.R
@@ -1,0 +1,59 @@
+# Tests fuer drop_attachments_without_file_metadata(): CentralStation liefert
+# gelegentlich Attachment-Objekte ohne Datei dahinter (leere / fehlgeschlagene
+# Uploads) mit content_type / file_size = NA. Diese Spalten sind im raw-Schema
+# NOT NULL, ein ungefilterter Upsert bricht den ganzen Ingestion-Job ab. Der
+# Helper muss solche Zeilen entfernen und warnen.
+
+make_attachments <- function() {
+  data.frame(
+    crm_attachment_id = c("aaaa-1111", "f7eda81c-empty", "bbbb-2222"),
+    user_id           = c(64L, 64L, 65L),
+    protocol_id       = c(10L, 11L, 12L),
+    filename          = c("a.pdf", NA, "b.pdf"),
+    content_type      = c("application/pdf", NA, "image/png"),
+    file_size         = c(1234L, NA, 5678L),
+    is_deleted        = c(FALSE, FALSE, FALSE),
+    stringsAsFactors  = FALSE
+  )
+}
+
+test_that("Zeile mit NA content_type wird entfernt, valide bleiben", {
+  out <- suppressWarnings(drop_attachments_without_file_metadata(make_attachments()))
+  expect_equal(nrow(out), 2L)
+  expect_equal(sort(out$crm_attachment_id), c("aaaa-1111", "bbbb-2222"))
+})
+
+test_that("Zeile mit NA file_size (aber gesetztem content_type) wird entfernt", {
+  att <- make_attachments()
+  att$content_type[2] <- "application/pdf"  # nur file_size fehlt
+  out <- suppressWarnings(drop_attachments_without_file_metadata(att))
+  expect_equal(nrow(out), 2L)
+  expect_false("f7eda81c-empty" %in% out$crm_attachment_id)
+})
+
+test_that("Warnung nennt die betroffene crm_attachment_id", {
+  expect_warning(
+    drop_attachments_without_file_metadata(make_attachments()),
+    "f7eda81c-empty"
+  )
+})
+
+test_that("vollstaendige Attachments bleiben unveraendert, keine Warnung", {
+  att <- make_attachments()[c(1, 3), ]
+  expect_warning(out <- drop_attachments_without_file_metadata(att), NA)
+  expect_equal(nrow(out), 2L)
+  expect_identical(out$crm_attachment_id, att$crm_attachment_id)
+})
+
+test_that("leerer Input liefert leeren Output ohne Fehler", {
+  att <- make_attachments()[0, ]
+  expect_warning(out <- drop_attachments_without_file_metadata(att), NA)
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("attachment_kind erscheint im Warntext", {
+  expect_warning(
+    drop_attachments_without_file_metadata(make_attachments(), attachment_kind = "comment"),
+    "comment"
+  )
+})


### PR DESCRIPTION
## Summary
- The daily `crm_update_protocols` ingestion job crashed on a CentralStation attachment that had **no file behind it** (`content_type`/`file_size` = `NA`), because both columns are `NOT NULL` in `raw.crm_lead_protocol_attachments`. One malformed upstream record aborted the whole 16-minute run and blocked every downstream step.
- Add a defensive guard that drops metadata-less attachments before the upsert and warns, so the job completes and the anomaly stays visible.

## Changes
### Added
- `drop_attachments_without_file_metadata()` in `R/crm_protocols.R` — removes rows where `content_type` or `file_size` is `NA`, raising a `warning()` that lists the affected `crm_attachment_id`s.
- `tests/testthat/test-crm_protocol_attachments.R` — 6 tests (TDD, written red-first): NA `content_type` dropped, NA `file_size` dropped, warning names the id, complete rows untouched with no warning, empty input safe, `attachment_kind` label in the message.

### Fixed
- Wired the guard into both download paths: `downloaded_attachments` (`"protocol"`) and `downloaded_comment_attachments` (`"comment"`). It sits after the existing `drop_na` filters and before the upsert, and only touches freshly-downloaded rows — DB-sourced deletion markers (which always carry metadata) are untouched.

## Technical notes
- Root cause is CRM-side data, not a code regression: all 128,711 prior attachments carried file metadata; the first metadata-less record (a UUID-keyed empty/failed upload, created 2026-06-25) was simply input the pipeline had never seen. UUID ids are normal here — the missing metadata is the anomaly.
- Any future failed/aborted upload in CentralStation would reproduce the crash, so the guard is warranted rather than a one-off cleanup.
- No backfill needed: the protocols/comments/relations steps had already committed before the failure; the next daily run re-covers the same window and drops the empty attachment.
- Centralized fix — covers every caller of `crm_update_protocols`, including base-58's `do/db_upload_protocols.R` and `one-off/redownload_truncated_protocols.R`. No duplicated definition to patch.

## Test plan
- [x] `testthat::test_file(...)` on the new test — 11 expectations pass
- [x] Full package suite green (`crm_protocol_attachments`, `example`, `fetch_with_retry`, `suppression`), 0 failures
- [ ] Next scheduled `crm_update_protocols` run completes past 2026-06-25 (warning logged for `f7eda81c-...`, no crash)